### PR TITLE
Fix/issue 2

### DIFF
--- a/src/Swatcher/Swatcher.csproj
+++ b/src/Swatcher/Swatcher.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Swatcher.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Config\SwatcherItemTypes.cs" />
+    <Compile Include="SwatcherFolderDeletedException.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/Swatcher/SwatcherFolderDeletedException.cs
+++ b/src/Swatcher/SwatcherFolderDeletedException.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BraveLantern.Swatcher.Config;
+
+namespace BraveLantern.Swatcher
+{
+    public sealed class SwatcherFolderDeletedException : DirectoryNotFoundException
+    {
+        public ISwatcherConfig Config { get; }
+
+        public SwatcherFolderDeletedException(ISwatcherConfig config, uint lastError)
+            :base(CreateExceptionMessage(config, lastError))
+        {
+            Config = config;
+        }
+
+        private static string CreateExceptionMessage(ISwatcherConfig config, uint lastError)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine($"The {nameof(Swatcher)}'s '{nameof(config.PathToWatch)}' appears to have been deleted; calling {nameof(ISwatcher.Stop)}.");
+            builder.AppendLine($"To resume the {nameof(Swatcher)}, recreate the folder and call the {nameof(ISwatcher.Start)} method.");
+            builder.AppendLine(
+                $"Otherwise, the {nameof(IDisposable.Dispose)} method should be called to cleanup system resources.");
+            builder.Append('-', 75);
+            builder.Append(Environment.NewLine);
+            builder.AppendLine($"{nameof(ISwatcherConfig.Id)} : {config.Id?.ToString() ?? "null"}");
+            builder.AppendLine($"{nameof(ISwatcherConfig.PathToWatch)} : {config.PathToWatch}");
+            builder.AppendLine($"Windows Error : {lastError}");
+
+            return builder.ToString();
+        }
+    }
+}


### PR DESCRIPTION
- Used `SafeSubscribe` for public api observables to ensure that observer will receive an OnError notification instead of breaking the observable internally.
- Leveraged the result from native `GetQueuedCompletedResult` method to determine if the folder is hosed. If so, call `Stop` and then throw the following exception.
- Created a new exception type, `SwatcherFolderDeletedException`, which will be sent when the watched folder has been deleted on a `ISwatcher` that is currently running. 